### PR TITLE
Remove submodule plenary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-deps/*
+tests/vendor/*
 bin/richclip

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tests/vendor/plenary.nvim"]
-	path = tests/vendor/plenary.nvim
-	url = https://github.com/nvim-lua/plenary.nvim

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,7 +5,7 @@ RUN=nvim --headless --noplugin -u init.vim
 .PHONY: all nvim test watch prepare
 
 prepare:
-	git submodule update --depth 1 --init
+	git clone --depth=1 https://github.com/nvim-lua/plenary.nvim vendor/plenary.nvim
 
 nvim:
 	@nvim --noplugin -u spec.vim


### PR DESCRIPTION
It seems Lazy's 'submodule=false' doesn't work.
Just remove the submodule, use 'make prepare' to get it.
