### PR TITLE
Add MacOS support to install script

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -34,7 +34,11 @@ download() {
         popd
         ;;
     Darwin*)
-        echoerr "Mac build is not available yet."
+        pushd "$TARGET_DIR"
+        curl -fsSL \
+            "https://github.com/beeender/richclip/releases/download/v${VERSION_STR}/richclip_v${VERSION_STR}_aarch64-apple-darwin.tar.gz" | \
+            tar -xz
+        popd
         ;;
     CYGWIN* | MINGW* | MSYS_NT*)
         echoerr "Windows build is not available yet."

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -35,9 +35,23 @@ download() {
         ;;
     Darwin*)
         pushd "$TARGET_DIR"
-        curl -fsSL \
-            "https://github.com/beeender/richclip/releases/download/v${VERSION_STR}/richclip_v${VERSION_STR}_aarch64-apple-darwin.tar.gz" | \
-            tar -xz
+        arch="$(uname -m)"
+        case "${arch}" in
+        arm64|aarch64)
+            curl -fsSL \
+                "https://github.com/beeender/richclip/releases/download/v${VERSION_STR}/richclip_v${VERSION_STR}_aarch64-apple-darwin.tar.gz" | \
+                tar -xz
+            ;;
+        x86_64)
+            curl -fsSL \
+                "https://github.com/beeender/richclip/releases/download/v${VERSION_STR}/richclip_v${VERSION_STR}_x86_64-apple-darwin.tar.gz" | \
+                tar -xz
+            ;;
+        *)
+            echoerr "Unsupported Darwin architecture: '${arch}'"
+            exit 1
+            ;;
+        esac
         popd
         ;;
     CYGWIN* | MINGW* | MSYS_NT*)

--- a/lua/richclip/binary.lua
+++ b/lua/richclip/binary.lua
@@ -4,9 +4,9 @@ local M = {}
 local config = require("richclip.config")
 local utils = require("richclip.utils")
 
-M._major_ver = '0'
-M._minor_ver = '2'
-M._patch_ver = '1'
+M._major_ver = "0"
+M._minor_ver = "3"
+M._patch_ver = "0"
 
 local current_file_dir = debug.getinfo(1).source:match('@?(.*/)')
 local current_file_dir_parts = vim.split(current_file_dir, '/')


### PR DESCRIPTION
The richclip binary is now available for macOS. Bumping the version in the install script to make install work cleanly on macOS.

Closes #7